### PR TITLE
Add gz-jetty-gui alias packages

### DIFF
--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -102,3 +102,11 @@ Description: Gazebo Gui classes and functions for robot apps - Development files
  designed to rapidly develop robot applications.
  .
  Package for development libraries and headers.
+
+Package: gz-jetty-gui
+Depends: libgz-gui10-dev (= ${binary:Version}), ${misc:Depends}
+Architecture: all
+Priority: optional
+Section: metapackages
+Description: alias package
+ Provides a package for Jetty without exposing the version number.


### PR DESCRIPTION
Add gz-jetty-gui* packages that depend on the
corresponding libgz-gui10* packages.

Part of https://github.com/gazebo-tooling/release-tools/issues/1326.